### PR TITLE
TEST fixes for Node 5.x: fix devDependencies & update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,31 @@
 language: node_js
+
 node_js:
-  - "iojs-v1.0.4"
+  - "5.7"
+  - "5.6"
+  - "4.3"
   - "0.12"
-  - "0.11"
+  - "0.10"
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install python-software-properties -qq
   - sudo add-apt-repository ppa:ondrej/php5-5.6 -y
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
   - sudo apt-get install -qq php5
+  - sudo apt-get install -qq gcc-4.8 -y
+
+install:
+  - CXX="g++-4.8" CC="gcc-4.8" npm install
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+
 email:
   on_success: never

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp-jshint": "*",
     "gulp-mocha": "*",
     "gulp-util": "*",
+    "jshint": "*",
     "jshint-stylish": "*",
     "mocha": "*",
     "must": "*",


### PR DESCRIPTION
TESTED in Travis-CI OK.

Unsupported versions dropped due to known security issues.

.travis.yml fixed with _some_ help from:
- http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
- https://github.com/audreyt/node-webworker-threads/blob/master/.travis.yml#L15-L25
